### PR TITLE
LINUXCN-24 Update path to config.sh for Linux, removed unused MANROOT_DIR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 
 <!--
     Copyright (c) 2014, Joyent, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # SDC Agents Core
 
-This repository is part of the SmartDataCenter (SDC) project. For
+This repository is part of the Triton DataCenter project. For
 contribution guidelines, issues, and general documentation, visit the
-[main SDC project](http://github.com/joyent/sdc).
+[main SDC project](http://github.com/TritonDataCenter/triton).
 
-SDC agents core bootstraps an agents installation onto a SmartDataCenter
+SDC agents core bootstraps an agents installation onto a Triton DataCenter
 headnode or compute nodes.
 
 ## License

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -6,6 +6,7 @@
 
 #
 # Copyright (c) 2014, Joyent, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 # Set up an NPM environment where we will install all the agents.
@@ -39,7 +40,6 @@ mkdir -p "$BIN_DIR"      \
          "$ETC_DIR"      \
          "$DB_DIR"       \
          "$NODE_MODULES" \
-         "$MANROOT_DIR"  \
          "$SMFDIR"       \
 
 NODE="/usr/node/bin/node"

--- a/npm/postinstall.sh
+++ b/npm/postinstall.sh
@@ -19,11 +19,16 @@ export ETC_DIR=$npm_config_etc
 export SMF_DIR=$npm_config_smfdir
 export VERSION=$npm_package_version
 
-if [[ "$(uname -s)" == "Linux" ]]; then
-    . /usr/triton/bin/config.sh
-else
-    . /lib/sdc/config.sh
-fi
+systype="$(uname -s)"
+case "$systype" in
+  Linux) config=/usr/triton/bin/config.sh ;;
+  SunOS) config=/lib/sdc/config.sh ;;
+  *)
+    printf 'Unsupported system type: %s\n' "$systype"
+    exit 1
+    ;;
+esac
+. "${config:?}"
 
 load_sdc_config
 

--- a/npm/postinstall.sh
+++ b/npm/postinstall.sh
@@ -7,6 +7,7 @@
 
 #
 # Copyright (c) 2015, Joyent, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 set -o xtrace
@@ -18,7 +19,12 @@ export ETC_DIR=$npm_config_etc
 export SMF_DIR=$npm_config_smfdir
 export VERSION=$npm_package_version
 
-. /lib/sdc/config.sh
+if [[ "$(uname -s)" == "Linux" ]]; then
+    . /usr/triton/bin/config.sh
+else
+    . /lib/sdc/config.sh
+fi
+
 load_sdc_config
 
 AGENT=$npm_package_name

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "agents_core",
-  "description": "Joyent SmartDC Agent Core",
-  "version": "2.2.2",
-  "author": "Joyent (joyent.com)",
+  "description": "Triton DataCenter Agent Core",
+  "version": "2.2.3",
+  "author": "MNX Cloud (mnx.io)",
   "private": true,
   "dependencies": {
     "amqp": "https://github.com/postwait/node-amqp.git#ae3a1435ac40379cb6f395085f3dc4444b649143",


### PR DESCRIPTION
Installing agents-core on Linux CN fails with:`mkdir: cannot create directory '': No such file or directory` which appears to be the result of `MANROOT_DIR` not being set (or used anywhere).

Also need to source `/usr/triton/bin/config.sh` on a Linux CN, instead of `/lib/sdc/config.sh`